### PR TITLE
[mellanox]: Align platform API: change CPLD version representation

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -154,7 +154,7 @@ class Chassis(ChassisBase):
         # Initialize component list
         from sonic_platform.component import ComponentBIOS, ComponentCPLD
         self._component_list.append(ComponentBIOS())
-        self._component_list.append(ComponentCPLD())
+        self._component_list.extend(ComponentCPLD.get_component_list())
 
 
     def get_name(self):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -23,10 +23,6 @@ ZERO = '0'
 COMMA = ','
 NEWLINE = '\n'
 
-#components definitions
-COMPONENT_BIOS = "BIOS"
-COMPONENT_CPLD = "CPLD"
-
 class Component(ComponentBase):
     def __init__(self):
         self.name = None


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Old style:
```bash
root@sonic:/home/admin# show platform firmware
Chassis                 Module    Component    Version                  Description
----------------------  --------  -----------  -----------------------  ---------------------------------------
x86_64-mlnx_msn3800-r0  N/A       BIOS         0ACLH004_02.02.003_9600  BIOS - Basic Input/Output System
                                  CPLD         5.3.3.1                  CPLD - includes all CPLDs in the switch

```

New style:
```bash
root@sonic:/home/admin# show platform firmware
Chassis                 Module    Component    Version                  Description
----------------------  --------  -----------  -----------------------  ----------------------------------------
x86_64-mlnx_msn3800-r0  N/A       BIOS         0ACLH004_02.02.007_9600  BIOS - Basic Input/Output System
                                  CPLD1        CPLD000000_REV0500       CPLD - Complex Programmable Logic Device
                                  CPLD2        CPLD000000_REV0300       CPLD - Complex Programmable Logic Device
                                  CPLD3        CPLD000000_REV0300       CPLD - Complex Programmable Logic Device
                                  CPLD4        CPLD000000_REV0100       CPLD - Complex Programmable Logic Device
```

**- What I did**
* Aligned platform API: changed CPLD version representation

**- How I did it**
* N/A

**- How to verify it**
1. Display platform firmware
```bash
show platform firmware
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
1. Show CPLD will show format will be: CPLDxxxxxx_REVmmnn
a. X: 6 digits of CPLD P/N
b. m: 2 digits of CPLD major version
c. n: 2 digits of CPLD minor version
2. In case CPLD P/N or minor version are not available use “0” in all not available digits

**- A picture of a cute animal (not mandatory but encouraged)**
