### PR TITLE
[Mellanox]: Fix PCIEd config for SN4600c

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/pcie.yaml
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/pcie.yaml
@@ -71,37 +71,37 @@
   name: 'USB controller: Intel Corporation 8 Series/C220 Series Chipset Family USB
     xHCI (rev 05)'
 - bus: '00'
-  dev: 1c
+  dev: '1c'
   fn: '0'
   id: 8c10
   name: 'PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express
     Root Port #1 (rev d5)'
 - bus: '00'
-  dev: 1c
+  dev: '1c'
   fn: '7'
   id: 8c1e
   name: 'PCI bridge: Intel Corporation 8 Series/C220 Series Chipset Family PCI Express
     Root Port #8 (rev d5)'
 - bus: '00'
-  dev: 1d
+  dev: '1d'
   fn: '0'
   id: 8c26
   name: 'USB controller: Intel Corporation 8 Series/C220 Series Chipset Family USB
     EHCI #1 (rev 05)'
 - bus: '00'
-  dev: 1f
+  dev: '1f'
   fn: '0'
   id: 8c54
   name: 'ISA bridge: Intel Corporation C224 Series Chipset Family Server Standard
     SKU LPC Controller (rev 05)'
 - bus: '00'
-  dev: 1f
+  dev: '1f'
   fn: '2'
   id: 8c02
   name: 'SATA controller: Intel Corporation 8 Series/C220 Series Chipset Family 6-port
     SATA Controller 1 [AHCI mode] (rev 05)'
 - bus: '00'
-  dev: 1f
+  dev: '1f'
   fn: '3'
   id: 8c22
   name: 'SMBus: Intel Corporation 8 Series/C220 Series Chipset Family SMBus Controller
@@ -130,289 +130,289 @@
   id: 6f53
   name: 'System peripheral: Intel Corporation Xeon Processor D Family QuickData Technology
     Register DMA Channel 3'
-- bus: '06'
+- bus: '07'
   dev: '00'
   fn: '0'
   id: cf70
   name: 'Ethernet controller: Mellanox Technologies Device cf70'
-- bus: 08
+- bus: '09'
   dev: '00'
   fn: '0'
-  id: '1533'
+  id: 1533
   name: 'Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev
     03)'
-- bus: ff
-  dev: 0b
+- bus: 'ff'
+  dev: '0b'
   fn: '0'
   id: 6f81
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D R3 QPI Link 0/1 (rev 03)'
-- bus: ff
-  dev: 0b
+- bus: 'ff'
+  dev: '0b'
   fn: '1'
   id: 6f36
   name: 'Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D R3 QPI Link 0/1 (rev 03)'
-- bus: ff
-  dev: 0b
+- bus: 'ff'
+  dev: '0b'
   fn: '2'
   id: 6f37
   name: 'Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D R3 QPI Link 0/1 (rev 03)'
-- bus: ff
-  dev: 0b
+- bus: 'ff'
+  dev: '0b'
   fn: '3'
   id: 6f76
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D R3 QPI Link Debug (rev 03)'
-- bus: ff
-  dev: 0c
+- bus: 'ff'
+  dev: '0c'
   fn: '0'
   id: 6fe0
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Caching Agent (rev 03)'
-- bus: ff
-  dev: 0c
+- bus: 'ff'
+  dev: '0c'
   fn: '1'
   id: 6fe1
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Caching Agent (rev 03)'
-- bus: ff
-  dev: 0c
+- bus: 'ff'
+  dev: '0c'
   fn: '2'
   id: 6fe2
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Caching Agent (rev 03)'
-- bus: ff
-  dev: 0c
+- bus: 'ff'
+  dev: '0c'
   fn: '3'
   id: 6fe3
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Caching Agent (rev 03)'
-- bus: ff
-  dev: 0f
+- bus: 'ff'
+  dev: '0f'
   fn: '0'
   id: 6ff8
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Caching Agent (rev 03)'
-- bus: ff
-  dev: 0f
+- bus: 'ff'
+  dev: '0f'
   fn: '4'
   id: 6ffc
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Caching Agent (rev 03)'
-- bus: ff
-  dev: 0f
+- bus: 'ff'
+  dev: '0f'
   fn: '5'
   id: 6ffd
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Caching Agent (rev 03)'
-- bus: ff
-  dev: 0f
+- bus: 'ff'
+  dev: '0f'
   fn: '6'
   id: 6ffe
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Caching Agent (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '10'
   fn: '0'
   id: 6f1d
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D R2PCIe Agent (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '10'
   fn: '1'
   id: 6f34
   name: 'Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D R2PCIe Agent (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '10'
   fn: '5'
   id: 6f1e
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Ubox (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '10'
   fn: '6'
   id: 6f7d
   name: 'Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Ubox (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '10'
   fn: '7'
   id: 6f1f
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Ubox (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '12'
   fn: '0'
   id: 6fa0
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Home Agent 0 (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '12'
   fn: '1'
   id: 6f30
   name: 'Performance counters: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Home Agent 0 (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '13'
   fn: '0'
   id: 6fa8
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Memory Controller 0 - Target Address/Thermal/RAS (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '13'
   fn: '1'
   id: 6f71
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Memory Controller 0 - Target Address/Thermal/RAS (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '13'
   fn: '2'
   id: 6faa
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Memory Controller 0 - Channel Target Address Decoder (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '13'
   fn: '3'
   id: 6fab
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Memory Controller 0 - Channel Target Address Decoder (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '13'
   fn: '4'
   id: 6fac
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Memory Controller 0 - Channel Target Address Decoder (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '13'
   fn: '5'
   id: 6fad
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Memory Controller 0 - Channel Target Address Decoder (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '13'
   fn: '6'
   id: 6fae
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D DDRIO Channel 0/1 Broadcast (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '13'
   fn: '7'
   id: 6faf
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D DDRIO Global Broadcast (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '14'
   fn: '0'
   id: 6fb0
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Memory Controller 0 - Channel 0 Thermal Control (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '14'
   fn: '1'
   id: 6fb1
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Memory Controller 0 - Channel 1 Thermal Control (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '14'
   fn: '2'
   id: 6fb2
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Memory Controller 0 - Channel 0 Error (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '14'
   fn: '3'
   id: 6fb3
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Memory Controller 0 - Channel 1 Error (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '14'
   fn: '4'
   id: 6fbc
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D DDRIO Channel 0/1 Interface (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '14'
   fn: '5'
   id: 6fbd
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D DDRIO Channel 0/1 Interface (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '14'
   fn: '6'
   id: 6fbe
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D DDRIO Channel 0/1 Interface (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '14'
   fn: '7'
   id: 6fbf
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D DDRIO Channel 0/1 Interface (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '15'
   fn: '0'
   id: 6fb4
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Memory Controller 0 - Channel 2 Thermal Control (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '15'
   fn: '1'
   id: 6fb5
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Memory Controller 0 - Channel 3 Thermal Control (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '15'
   fn: '2'
   id: 6fb6
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Memory Controller 0 - Channel 2 Error (rev 03)'
-- bus: ff
+- bus: 'ff'
   dev: '15'
   fn: '3'
   id: 6fb7
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Memory Controller 0 - Channel 3 Error (rev 03)'
-- bus: ff
-  dev: 1e
+- bus: 'ff'
+  dev: '1e'
   fn: '0'
   id: 6f98
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Power Control Unit (rev 03)'
-- bus: ff
-  dev: 1e
+- bus: 'ff'
+  dev: '1e'
   fn: '1'
   id: 6f99
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Power Control Unit (rev 03)'
-- bus: ff
-  dev: 1e
+- bus: 'ff'
+  dev: '1e'
   fn: '2'
   id: 6f9a
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Power Control Unit (rev 03)'
-- bus: ff
-  dev: 1e
+- bus: 'ff'
+  dev: '1e'
   fn: '3'
   id: 6fc0
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Power Control Unit (rev 03)'
-- bus: ff
-  dev: 1e
+- bus: 'ff'
+  dev: '1e'
   fn: '4'
   id: 6f9c
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Power Control Unit (rev 03)'
-- bus: ff
-  dev: 1f
+- bus: 'ff'
+  dev: '1f'
   fn: '0'
   id: 6f88
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon
     D Power Control Unit (rev 03)'
-- bus: ff
-  dev: 1f
+- bus: 'ff'
+  dev: '1f'
   fn: '2'
   id: 6f8a
   name: 'System peripheral: Intel Corporation Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

PCIEd pollutes log with the next errors:
```
Feb 25 14:20:06.051698 sonic WARNING pmon#pcied[66]: PCIe Device: Ethernet controller: Mellanox Technologies Device cf70 Not Found
Feb 25 14:20:06.051698 sonic WARNING pmon#pcied[66]: PCIe Device: Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03) Not Found
Feb 25 14:20:06.052063 sonic ERR pmon#pcied[66]: PCIe device status check : FAILED
```

#### Why I did it
* To fix PCIEd log errors

#### How I did it
* Fixed `pcie.yaml`

#### How to verify it
1. supervisorctl restart pcied

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```