### PR TITLE
[teamd]: Downgrade supervisord (python3->python2) to overcome LAG cleanup degradation

### DIFF
--- a/dockers/docker-teamd/Dockerfile.j2
+++ b/dockers/docker-teamd/Dockerfile.j2
@@ -17,6 +17,22 @@ RUN apt-get update
 {{ install_debian_packages(docker_teamd_debs.split(' ')) }}
 {%- endif %}
 
+# W/A: install python2
+RUN apt-get -y --no-install-recommends install python2.7 python-pip
+
+# W/A: upgrade pip via PyPI and uninstall the Debian version
+RUN pip2 install --upgrade pip
+
+# W/A: setuptools and wheel are necessary for installing some Python wheel packages
+RUN pip2 install --no-cache-dir setuptools==44.1.1
+RUN pip2 install --no-cache-dir wheel==0.35.1
+
+# W/A: install supervisor
+RUN pip2 install supervisor==4.2.1
+
+# W/A: add support for supervisord to handle startup dependencies
+RUN pip2 install supervisord-dependent-startup==1.4.0
+
 RUN apt-get clean -y      && \
     apt-get autoclean -y  && \
     apt-get autoremove -y && \


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

