### PR TITLE
[trim]: Add Packet Trimming Asym DSCP YANG model

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -71,6 +71,7 @@
   * [Restapi](#restapi)
   * [System Port](#system-port)
   * [Tacplus Server](#tacplus-server)
+  * [TC to DSCP map](#tc-to-dscp-map)
   * [TC to Priority group map](#tc-to-priority-group-map)
   * [TC to Queue map](#tc-to-queue-map)
   * [Telemetry](#telemetry)
@@ -2443,6 +2444,21 @@ and is listed in this table.
 }
 ```
 
+### TC to DSCP map
+
+```json
+{
+    "TC_TO_DSCP_MAP": {
+        "AZURE": {
+            "5": "10",
+            "6": "20"
+        }
+    }
+}
+```
+
+**Note:**
+* configuration is mandatory when packet trimming Asymmetric DSCP mode is used
 
 ### TC to Priority group map
 
@@ -2595,7 +2611,8 @@ and try sending it on a different queue to deliver a packet drop notification to
 
 ***TRIMMING***
 
-```
+Symmetric DSCP and static queue:
+```json
 {
     "SWITCH_TRIMMING": {
         "GLOBAL": {
@@ -2607,7 +2624,22 @@ and try sending it on a different queue to deliver a packet drop notification to
 }
 ```
 
+Asymmetric DSCP and dynamic queue:
+```json
+{
+    "SWITCH_TRIMMING": {
+        "GLOBAL": {
+            "size": "128",
+            "dscp_value": "from-tc",
+            "tc_value": "8",
+            "queue_index": "dynamic"
+        }
+    }
+}
+```
+
 **Note:**
+* when `dscp_value` is set to `from-tc`, the `tc_value` is used for mapping to DSCP
 * when `queue_index` is set to `dynamic`, the `dscp_value` is used for mapping to queue
 
 ### Versions

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -378,7 +378,8 @@
         "SWITCH_TRIMMING": {
             "GLOBAL": {
                 "size": "128",
-                "dscp_value": "48",
+                "dscp_value": "from-tc",
+                "tc_value": "6",
                 "queue_index": "6"
             }
         },

--- a/src/sonic-yang-models/tests/yang_model_pytests/test_trimming.py
+++ b/src/sonic-yang-models/tests/yang_model_pytests/test_trimming.py
@@ -3,19 +3,26 @@ import pytest
 
 class TestTrimming:
     @pytest.mark.parametrize(
-        "index", [
-            pytest.param('6', id="static"),
-            pytest.param('dynamic', id="dynamic")
+        "queue", [
+            pytest.param('6', id="queue-static"),
+            pytest.param('dynamic', id="queue-dynamic")
         ]
     )
-    def test_valid_data(self, yang_model, index):
+    @pytest.mark.parametrize(
+        "dscp", [
+            pytest.param('48', id="dscp-symmetric"),
+            pytest.param('from-tc', id="dscp-asymmetric")
+        ]
+    )
+    def test_valid_data(self, yang_model, dscp, queue):
         data = {
             "sonic-trimming:sonic-trimming": {
                 "sonic-trimming:SWITCH_TRIMMING": {
                     "GLOBAL": {
                         "size": "128",
-                        "dscp_value": "48",
-                        "queue_index": index
+                        "dscp_value": dscp,
+                        "tc_value": "6",
+                        "queue_index": queue
                     }
                 }
             }
@@ -45,7 +52,7 @@ class TestTrimming:
     @pytest.mark.parametrize(
         "dscp,error_message", [
             pytest.param('-1', 'Invalid value', id="min-1"),
-            pytest.param('64', 'Invalid DSCP value', id="max+1")
+            pytest.param('64', 'Invalid value', id="max+1")
         ]
     )
     def test_neg_dscp_value(self, yang_model, dscp, error_message):
@@ -62,17 +69,36 @@ class TestTrimming:
         yang_model.load_data(data, error_message)
 
     @pytest.mark.parametrize(
-        "index,error_message", [
+        "tc,error_message", [
             pytest.param('-1', 'Invalid value', id="min-1"),
             pytest.param('256', 'Invalid value', id="max+1")
         ]
     )
-    def test_neg_queue_index(self, yang_model, index, error_message):
+    def test_neg_tc_value(self, yang_model, tc, error_message):
         data = {
             "sonic-trimming:sonic-trimming": {
                 "sonic-trimming:SWITCH_TRIMMING": {
                     "GLOBAL": {
-                        "queue_index": index
+                        "tc_value": tc
+                    }
+                }
+            }
+        }
+
+        yang_model.load_data(data, error_message)
+
+    @pytest.mark.parametrize(
+        "queue,error_message", [
+            pytest.param('-1', 'Invalid value', id="min-1"),
+            pytest.param('256', 'Invalid value', id="max+1")
+        ]
+    )
+    def test_neg_queue_index(self, yang_model, queue, error_message):
+        data = {
+            "sonic-trimming:sonic-trimming": {
+                "sonic-trimming:SWITCH_TRIMMING": {
+                    "GLOBAL": {
+                        "queue_index": queue
                     }
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-trimming.yang
+++ b/src/sonic-yang-models/yang-models/sonic-trimming.yang
@@ -25,19 +25,31 @@ module sonic-trimming {
                 }
 
                 leaf dscp_value {
-                    description "DSCP value assigned to a packet after trimming";
-                    type uint8 {
-                        range "0..63" {
-                            error-message "Invalid DSCP value";
-                            error-app-tag dscp-invalid;
+                    description
+                        "DSCP value assigned to a packet after trimming.
+                        When set to from-tc, the tc_value is used for mapping to the DSCP";
+                    type union {
+                        type uint8 {
+                            range "0..63" {
+                                error-message "Invalid DSCP value";
+                                error-app-tag dscp-invalid;
+                            }
+                        }
+                        type string {
+                            pattern "from-tc";
                         }
                     }
+                }
+
+                leaf tc_value {
+                    description "TC value assigned to a packet after trimming";
+                    type uint8;
                 }
 
                 leaf queue_index {
                     description
                         "Queue index to use for transmission of a packet after trimming.
-                        When set to dynamic, the dscp_value is used for mapping to queue";
+                        When set to dynamic, the dscp_value is used for mapping to the queue";
                     type union {
                         type uint8;
                         type string {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

